### PR TITLE
Improve documentation and prevent roles with similar names from causing false positives

### DIFF
--- a/parser/Assets/BocuD/PatreonParser/PatreonDecoder.asset
+++ b/parser/Assets/BocuD/PatreonParser/PatreonDecoder.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c333ccfdd0cbdbc4ca30cef2dd6e6b9b, type: 3}
   m_Name: PatreonDecoder
   m_EditorClassIdentifier: 
-  serializedUdonProgramAsset: {fileID: 11400000, guid: 7a66eaa859ee8b54db8d13b917cb43d9,
+  serializedUdonProgramAsset: {fileID: 11400000, guid: 070e8b6359f0918439d2785bf920256c,
     type: 2}
   udonAssembly: 
   assemblyError: 
@@ -25,7 +25,7 @@ MonoBehaviour:
     SerializedFormat: 2
     SerializedBytes: 
     ReferencedUnityObjects:
-    - {fileID: 11500000, guid: 135088d4455c591469fc5374c41e8ff5, type: 3}
+    - {fileID: 11500000, guid: ba25782b0e79ce84a94f2d50552289b5, type: 3}
     SerializedBytesString: 
     Prefab: {fileID: 0}
     PrefabModificationsReferencedUnityObjects: []
@@ -50,7 +50,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: avatarImagePrefab
+      Data: readRenderTexture
     - Name: $v
       Entry: 7
       Data: 2|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -62,7 +62,7 @@ MonoBehaviour:
       Data: 4|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
-      Data: AvatarImageReader.AvatarImagePrefab, Assembly-CSharp
+      Data: AvatarImageReader.ReadRenderTexture, Assembly-CSharp
     - Name: 
       Entry: 8
       Data: 
@@ -77,10 +77,10 @@ MonoBehaviour:
       Data: VRCUdonUdonBehaviour
     - Name: symbolOriginalName
       Entry: 1
-      Data: avatarImagePrefab
+      Data: readRenderTexture
     - Name: symbolUniqueName
       Entry: 1
-      Data: avatarImagePrefab
+      Data: readRenderTexture
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -119,7 +119,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: roleNames
+      Data: outputTMPs
     - Name: $v
       Entry: 7
       Data: 7|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -129,6 +129,138 @@ MonoBehaviour:
     - Name: internalType
       Entry: 7
       Data: 9|System.RuntimeType, mscorlib
+    - Name: 
+      Entry: 1
+      Data: TMPro.TextMeshPro[], Unity.TextMeshPro
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: declarationType
+      Entry: 3
+      Data: 1
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: TMProTextMeshProArray
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: outputTMPs
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: outputTMPs
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 10|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 11|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: outputHeaders
+    - Name: $v
+      Entry: 7
+      Data: 12|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 13|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
+      Entry: 9
+      Data: 9
+    - Name: declarationType
+      Entry: 3
+      Data: 1
+    - Name: syncMode
+      Entry: 3
+      Data: 0
+    - Name: symbolResolvedTypeName
+      Entry: 1
+      Data: TMProTextMeshProArray
+    - Name: symbolOriginalName
+      Entry: 1
+      Data: outputHeaders
+    - Name: symbolUniqueName
+      Entry: 1
+      Data: outputHeaders
+    - Name: symbolDefaultValue
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: fieldAttributes
+      Entry: 7
+      Data: 14|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+    - Name: 
+      Entry: 12
+      Data: 1
+    - Name: 
+      Entry: 7
+      Data: 15|UnityEngine.SerializeField, UnityEngine.CoreModule
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: userBehaviourSource
+      Entry: 6
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: 
+    - Name: $k
+      Entry: 1
+      Data: roleNames
+    - Name: $v
+      Entry: 7
+      Data: 16|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+    - Name: fieldSymbol
+      Entry: 7
+      Data: 17|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+    - Name: internalType
+      Entry: 7
+      Data: 18|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.String[], mscorlib
@@ -158,148 +290,10 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 10|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 19|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
-    - Name: 
-      Entry: 7
-      Data: 11|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
-    - Name: header
-      Entry: 1
-      Data: 'Required: Role names'
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: userBehaviourSource
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: roleStrings
-    - Name: $v
-      Entry: 7
-      Data: 12|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: fieldSymbol
-      Entry: 7
-      Data: 13|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
-    - Name: internalType
-      Entry: 9
-      Data: 9
-    - Name: declarationType
-      Entry: 3
-      Data: 2
-    - Name: syncMode
-      Entry: 3
-      Data: 0
-    - Name: symbolResolvedTypeName
-      Entry: 1
-      Data: SystemStringArray
-    - Name: symbolOriginalName
-      Entry: 1
-      Data: roleStrings
-    - Name: symbolUniqueName
-      Entry: 1
-      Data: roleStrings
-    - Name: symbolDefaultValue
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: fieldAttributes
-      Entry: 7
-      Data: 14|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 0
-    - Name: 
-      Entry: 13
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: userBehaviourSource
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: 
-      Entry: 7
-      Data: 
-    - Name: $k
-      Entry: 1
-      Data: outputHeaders
-    - Name: $v
-      Entry: 7
-      Data: 15|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
-    - Name: fieldSymbol
-      Entry: 7
-      Data: 16|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
-    - Name: internalType
-      Entry: 7
-      Data: 17|System.RuntimeType, mscorlib
-    - Name: 
-      Entry: 1
-      Data: TMPro.TextMeshPro[], Unity.TextMeshPro
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: declarationType
-      Entry: 3
-      Data: 1
-    - Name: syncMode
-      Entry: 3
-      Data: 0
-    - Name: symbolResolvedTypeName
-      Entry: 1
-      Data: TMProTextMeshProArray
-    - Name: symbolOriginalName
-      Entry: 1
-      Data: outputHeaders
-    - Name: symbolUniqueName
-      Entry: 1
-      Data: outputHeaders
-    - Name: symbolDefaultValue
-      Entry: 6
-      Data: 
-    - Name: 
-      Entry: 8
-      Data: 
-    - Name: fieldAttributes
-      Entry: 7
-      Data: 18|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
-    - Name: 
-      Entry: 12
-      Data: 2
-    - Name: 
-      Entry: 7
-      Data: 19|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
-    - Name: header
-      Entry: 1
-      Data: 'Optional: Fill TMPs with lists for each role'
-    - Name: 
-      Entry: 8
-      Data: 
     - Name: 
       Entry: 7
       Data: 20|UnityEngine.SerializeField, UnityEngine.CoreModule
@@ -326,7 +320,7 @@ MonoBehaviour:
       Data: 
     - Name: $k
       Entry: 1
-      Data: outputTMPs
+      Data: roleStrings
     - Name: $v
       Entry: 7
       Data: 21|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
@@ -335,22 +329,22 @@ MonoBehaviour:
       Data: 22|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
-      Data: 17
+      Data: 18
     - Name: declarationType
       Entry: 3
-      Data: 1
+      Data: 2
     - Name: syncMode
       Entry: 3
       Data: 0
     - Name: symbolResolvedTypeName
       Entry: 1
-      Data: TMProTextMeshProArray
+      Data: SystemStringArray
     - Name: symbolOriginalName
       Entry: 1
-      Data: outputTMPs
+      Data: roleStrings
     - Name: symbolUniqueName
       Entry: 1
-      Data: outputTMPs
+      Data: roleStrings
     - Name: symbolDefaultValue
       Entry: 6
       Data: 
@@ -362,13 +356,7 @@ MonoBehaviour:
       Data: 23|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 24|UnityEngine.SerializeField, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
+      Data: 0
     - Name: 
       Entry: 13
       Data: 
@@ -392,13 +380,13 @@ MonoBehaviour:
       Data: decodeFinished
     - Name: $v
       Entry: 7
-      Data: 25|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 24|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 26|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 25|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 7
-      Data: 27|System.RuntimeType, mscorlib
+      Data: 26|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Boolean, mscorlib
@@ -428,16 +416,10 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 28|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 27|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
-      Data: 1
-    - Name: 
-      Entry: 7
-      Data: 29|UnityEngine.HideInInspector, UnityEngine.CoreModule
-    - Name: 
-      Entry: 8
-      Data: 
+      Data: 0
     - Name: 
       Entry: 13
       Data: 
@@ -461,13 +443,13 @@ MonoBehaviour:
       Data: sendCustomEvent
     - Name: $v
       Entry: 7
-      Data: 30|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 28|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 31|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 29|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
-      Data: 27
+      Data: 26
     - Name: declarationType
       Entry: 3
       Data: 1
@@ -491,16 +473,16 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 32|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 30|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 1
     - Name: 
       Entry: 7
-      Data: 33|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
+      Data: 31|UnityEngine.HeaderAttribute, UnityEngine.CoreModule
     - Name: header
       Entry: 1
-      Data: On Decode Finish
+      Data: On Decode
     - Name: 
       Entry: 8
       Data: 
@@ -527,13 +509,13 @@ MonoBehaviour:
       Data: targetBehaviour
     - Name: $v
       Entry: 7
-      Data: 34|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 32|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 35|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 33|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 7
-      Data: 36|System.RuntimeType, mscorlib
+      Data: 34|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: VRC.Udon.UdonBehaviour, VRC.Udon
@@ -563,7 +545,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 37|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 35|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -590,13 +572,13 @@ MonoBehaviour:
       Data: eventName
     - Name: $v
       Entry: 7
-      Data: 38|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 36|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 39|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 37|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 7
-      Data: 40|System.RuntimeType, mscorlib
+      Data: 38|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.String, mscorlib
@@ -626,7 +608,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 41|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 39|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -653,13 +635,13 @@ MonoBehaviour:
       Data: currentStep
     - Name: $v
       Entry: 7
-      Data: 42|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 40|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 43|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 41|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 7
-      Data: 44|System.RuntimeType, mscorlib
+      Data: 42|System.RuntimeType, mscorlib
     - Name: 
       Entry: 1
       Data: System.Int32, mscorlib
@@ -689,7 +671,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 45|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 43|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0
@@ -716,13 +698,13 @@ MonoBehaviour:
       Data: localPlayerRoles
     - Name: $v
       Entry: 7
-      Data: 46|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
+      Data: 44|UdonSharp.Compiler.FieldDefinition, UdonSharp.Editor
     - Name: fieldSymbol
       Entry: 7
-      Data: 47|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
+      Data: 45|UdonSharp.Compiler.SymbolDefinition, UdonSharp.Editor
     - Name: internalType
       Entry: 9
-      Data: 40
+      Data: 38
     - Name: declarationType
       Entry: 3
       Data: 2
@@ -746,7 +728,7 @@ MonoBehaviour:
       Data: 
     - Name: fieldAttributes
       Entry: 7
-      Data: 48|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
+      Data: 46|System.Collections.Generic.List`1[[System.Attribute, mscorlib]], mscorlib
     - Name: 
       Entry: 12
       Data: 0

--- a/parser/Assets/BocuD/PatreonParser/PatreonDecoder.cs
+++ b/parser/Assets/BocuD/PatreonParser/PatreonDecoder.cs
@@ -5,162 +5,151 @@ using UnityEngine;
 using VRC.SDKBase;
 using VRC.Udon;
 
-namespace BocuD.PatreonParser
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+public class PatreonDecoder : UdonSharpBehaviour
 {
-    [UdonBehaviourSyncMode(BehaviourSyncMode.None)]
-    public class PatreonDecoder : UdonSharpBehaviour
+    [SerializeField] private ReadRenderTexture readRenderTexture;
+
+    [SerializeField] private TextMeshPro[] outputTMPs;
+    [SerializeField] private TextMeshPro[] outputHeaders;
+    [SerializeField] private string[] roleNames;
+    private string[] roleStrings;
+    public bool decodeFinished;
+
+    [Header("On Decode")] 
+    public bool sendCustomEvent;
+    public UdonBehaviour targetBehaviour;
+    public string eventName;
+    
+    public void _StartDecode()
     {
-        [SerializeField] private AvatarImagePrefab avatarImagePrefab;
-    
-        [Header("Required: Role names")]
-        public string[] roleNames;
-    
-        private string[] roleStrings;
-
-        [Header("Optional: Fill TMPs with lists for each role")]
-        [SerializeField] private TextMeshPro[] outputHeaders;
-        [SerializeField] private TextMeshPro[] outputTMPs;
-    
-        [HideInInspector] public bool decodeFinished;
-
-        [Header("On Decode Finish")]
-        public bool sendCustomEvent;
-        public UdonBehaviour targetBehaviour;
-        public string eventName;
-    
-        public void _StartDecode()
-        {
-            Debug.Log("[<color=blue>VRCPatreonLink</color>] Starting decode...");
+        Debug.Log("[<color=blue>VRCPatreonLink</color>] Starting decode...");
         
-            //different roles are split by newline
-            string[] splitText = avatarImagePrefab.outputString.Split('\n');
-            roleStrings = new string[roleNames.Length];
+        //different roles are split by newline
+        string[] splitText = readRenderTexture.outputString.Split('\n');
+        roleStrings = new string[roleNames.Length];
 
-            for (int index = 0; index < roleStrings.Length; index++)
-            {
-                roleStrings[index] = "";
-            }
-
-            //match each line to its role equivalent
-            foreach (string s in splitText)
-            {
-                //loop through all possible roles to try to find a match
-                for (int role = 0; role < roleNames.Length; role++)
-                {
-                    //skip if the line doesn't start with the predetermined role name
-                    if (!s.StartsWith(roleNames[role])) continue;
-                
-                    roleStrings[role] = s;
-                }
-            }
-
-            //Start decoding the strings (loops through patrons, hence why its split over multiple batches based on each role)
-            _DecodeStep();
+        for (int index = 0; index < roleStrings.Length; index++)
+        {
+            roleStrings[index] = "";
         }
 
-        private int currentStep = 0;
-        public void _DecodeStep()
+        //match each line to its role equivalent
+        foreach (string s in splitText)
         {
-            Debug.Log($"[<color=blue>VRCPatreonLink</color>] Decoding list... Step {currentStep}");
-            if (currentStep < roleNames.Length)
-            {
-                //only proceed if this role was matched
-                if (roleStrings[currentStep].Length > 0)
-                {
-                    DecodeList(roleStrings[currentStep], outputTMPs[currentStep], outputHeaders[currentStep]);
-                }
-                currentStep++;
-                SendCustomEventDelayedFrames(nameof(_DecodeStep), 5);
-            }
-            else
-            {
-                Debug.Log($"[<color=blue>VRCPatreonLink</color>] Finished! Running callback...");
-                if (sendCustomEvent)
-                {
-                    if (targetBehaviour != null && eventName.Length > 0)
-                    {
-                        targetBehaviour.SendCustomEvent(eventName);
-                    }
-                }
-
-                decodeFinished = true;
-            }
-        }
-
-        private void DecodeList(string input, TextMeshPro target, TextMeshPro header)
-        {
-            string[] users = input.Split('.');
-            string output = "";
-
-            string playerName = Networking.LocalPlayer.displayName;
-
-            for (int index = 1; index < users.Length; index++)
-            {
-                output += users[index];
-                output += '\n';
-
-                if (users[index] == playerName)
-                {
-                    Debug.Log($"[<color=blue>VRCPatreonLink</color>] Local player has rank {users[0]}");
-                    localPlayerRoles += users[0];
-                }
-            }
-
-            if (header != null)
-                header.text = users[0];
-
-            if (target != null)
-                target.text = output;
-        }
-
-        private string localPlayerRoles = "";
-
-        /// <summary>
-        /// Check if the local player has the specified role
-        /// Should only be called once decoding has finished
-        /// </summary>
-        /// <param name="targetRole">Role to search for</param>
-        /// <returns>true if the player has the specified role</returns>
-        public bool _LocalPlayerHasRole(string targetRole)
-        {
-            return localPlayerRoles.Contains(targetRole);
-        }
-
-        /// <summary>
-        /// Returns an array of player display names for the specified role
-        /// </summary>
-        /// <param name="targetRole">The discord role name</param>
-        /// <returns>String array</returns>
-        public string[] _GetPatronsByString(string targetRole)
-        {
-            //try to match the input string to a role
-            int roleID = -1;
-        
             //loop through all possible roles to try to find a match
             for (int role = 0; role < roleNames.Length; role++)
             {
-                if (targetRole == roleNames[role]) roleID = role;
+                //skip if the line doesn't start with the predetermined role name
+                if (!s.StartsWith(roleNames[role])) continue;
+                
+                roleStrings[role] = s;
+            }
+        }
+
+        //Start decoding the strings (loops through patrons, hence why its split over multiple batches based on each role)
+        _DecodeStep();
+    }
+
+    private int currentStep = 0;
+    public void _DecodeStep()
+    {
+        Debug.Log($"[<color=blue>VRCPatreonLink</color>] Decoding list... Step {currentStep}");
+        if (currentStep < roleNames.Length)
+        {
+            //only proceed if this role was matched
+            if (roleStrings[currentStep].Length > 0)
+            {
+                _DecodeList(roleStrings[currentStep], outputTMPs[currentStep], outputHeaders[currentStep]);
+            }
+            currentStep++;
+            SendCustomEventDelayedFrames(nameof(_DecodeStep), 5);
+        }
+        else
+        {
+            Debug.Log($"[<color=blue>VRCPatreonLink</color>] Finished! Running callback...");
+            if (sendCustomEvent)
+            {
+                if (targetBehaviour != null && eventName.Length > 0)
+                {
+                    targetBehaviour.SendCustomEvent(eventName);
+                }
             }
 
-            if (roleID != -1)
-            {
-                return _GetPatronsFromID(roleID);
-            }
-            else
-            {
-                return new string[0];
-            }
+            decodeFinished = true;
         }
-    
-        public string[] _GetPatronsFromID(int roleID)
+    }
+
+    private void _DecodeList(string input, TextMeshPro target, TextMeshPro header)
+    {
+        string[] users = input.Split('.');
+        string output = "";
+
+        string playerName = Networking.LocalPlayer.displayName;
+
+        for (int index = 1; index < users.Length; index++)
         {
-            if (roleID < roleStrings.Length)
+            output += users[index];
+            output += '\n';
+
+            if (users[index] == playerName)
             {
-                //get rid of the period after the role name
-                string splitString = roleStrings[roleID].Substring(roleNames[roleID].Length);
-                return splitString.Split('.');
+                Debug.Log($"[<color=blue>VRCPatreonLink</color>] Local player has rank {users[0]}");
+                localPlayerRoles += users[0] + ".";
             }
-            else return new string[0];
         }
+
+        header.text = users[0];
+        target.text = output;
+    }
+
+    private string localPlayerRoles = "";
+
+    /// <summary>
+    /// Check if the local player has the specified role
+    /// Should only be called once decoding has finished
+    /// </summary>
+    /// <param name="rank">Role to search for</param>
+    /// <returns>true if the player has the specified role</returns>
+    public bool LocalPlayerHasRole(string rank)
+    {
+        return localPlayerRoles.Contains(rank + ".");
+    }
+
+    /// <summary>
+    /// Returns an array of player display names for the specified role
+    /// </summary>
+    /// <param name="targetRole">The discord role name</param>
+    /// <returns>String array</returns>
+    public string[] _GetPatronsByString(string targetRole)
+    {
+        //try to match the input string to a role
+        int roleID = -1;
+        
+        //loop through all possible roles to try to find a match
+        for (int role = 0; role < roleNames.Length; role++)
+        {
+            if (targetRole == roleNames[role]) roleID = role;
+        }
+
+        if (roleID != -1)
+        {
+            return _GetPatronsFromID(roleID);
+        }
+        else
+        {
+            return new string[0];
+        }
+    }
+    
+    public string[] _GetPatronsFromID(int roleID)
+    {
+        if (roleID < roleStrings.Length)
+        {
+            //get rid of the period after the role name
+            string splitString = roleStrings[roleID].Substring(roleNames[roleID].Length);
+            return splitString.Split('.');
+        }
+        else return new string[0];
     }
 }


### PR DESCRIPTION
Example: If the roles role and role2 were set up, checking if the player has role when they only had role2 would false positive.